### PR TITLE
Allow connecting to arbitrary domain DC

### DIFF
--- a/lib/smart_proxy_realm_ad/plugin.rb
+++ b/lib/smart_proxy_realm_ad/plugin.rb
@@ -7,7 +7,7 @@ module Proxy::AdRealm
     load_classes ::Proxy::AdRealm::ConfigurationLoader
     load_dependency_injection_wirings ::Proxy::AdRealm::ConfigurationLoader
 
-    validate_presence :realm, :keytab_path, :principal, :domain_controller
+    validate_presence :realm, :keytab_path, :principal
     validate_readable :keytab_path
 
     plugin :realm_ad, ::Proxy::AdRealm::VERSION

--- a/lib/smart_proxy_realm_ad/provider.rb
+++ b/lib/smart_proxy_realm_ad/provider.rb
@@ -88,7 +88,7 @@ module Proxy::AdRealm
       # Connect to active directory
       conn = Adcli::AdConn.new(@domain)
       conn.set_domain_realm(@realm)
-      conn.set_domain_controller(@domain_controller)
+      conn.set_domain_controller(@domain_controller) unless @domain_controller.nil?
       conn.set_login_ccache_name('')
       conn.connect
       conn


### PR DESCRIPTION
adcli will automatically grab SRV records to decide on a DC to connect to if not given an explicit DC FQDN.

With this change it would be as simple as not providing a `:domain_controller` value in the config to exploit this functionality.
This would allow for provisioning machine accounts even during AD DC updates or migrations.

References:
`connect_to_directory` for connecting to the AD directory: https://cgit.freedesktop.org/realmd/adcli/tree/library/adconn.c#n958
`disco_dance_if_necessary` for discovering connection properties: https://cgit.freedesktop.org/realmd/adcli/tree/library/adconn.c#n115
`adcli_disco_domain` for finding all available DCs in a domain: https://cgit.freedesktop.org/realmd/adcli/tree/library/addisco.c#n712