### PR TITLE
Allow prefix to be empty

### DIFF
--- a/lib/smart_proxy_realm_ad/provider.rb
+++ b/lib/smart_proxy_realm_ad/provider.rb
@@ -17,8 +17,8 @@ module Proxy::AdRealm
       @domain_controller = options[:domain_controller]
       @domain = options[:realm].downcase
       @ou = options[:ou]
-      @computername_prefix = options[:computername_prefix]
-      @computername_hash = options[:computername_hash]
+      @computername_prefix = options.fetch(:computername_prefix, '')
+      @computername_hash = options.fetch(:computername_hash, @null)
       @computername_use_fqdn = options[:computername_use_fqdn]
       logger.info 'Proxy::AdRealm: initialize...'
     end
@@ -76,7 +76,20 @@ module Proxy::AdRealm
     end
 
     def apply_computername_prefix?(computername)
-      !computername_prefix.nil? && !computername_prefix.empty? && (computername_hash || !computername[0, computername_prefix.size].casecmp(computername_prefix).zero?)
+      # Return false if computername is nil or empty
+      return false if computername.nil? || computername.empty?
+
+      # Return false if computername_prefix is nil or empty
+      return false if computername_prefix.nil? || computername_prefix.empty?
+
+      # Extract the prefix from computername with the same length as computername_prefix
+      extracted_prefix = computername[0, computername_prefix.size]
+
+      # Check if prefix is already in the beginning of computername string
+      prefix_matches = extracted_prefix.casecmp(computername_prefix).zero?
+      
+      # Return true if computername_hash is non empty or if the prefix does not match
+      computername_hash || !prefix_matches
     end
 
     def kinit_radcli_connect

--- a/smart_proxy_realm_ad_plugin.gemspec
+++ b/smart_proxy_realm_ad_plugin.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.test_files  = Dir['test/**/*']
 
   s.add_development_dependency('rake')
-  s.add_development_dependency('mocha')
+  s.add_development_dependency('mocha', '~> 1.3.0')
   s.add_development_dependency('test-unit')
   s.add_dependency('rkerberos')
   s.add_dependency('radcli')


### PR DESCRIPTION
This change improve the code to see if computername_prefix should be applied or not.

We should not crash if computername_prefix is not set. computername_prefix is an optional configuration parameter.

Improved the apply_computername_prefix to make it more robust and easy to understand.

This will fix: https://github.com/theforeman/smart_proxy_realm_ad_plugin/issues/28

