### PR TITLE
Clarify default DC discovery

### DIFF
--- a/config/realm_ad.yml.example
+++ b/config/realm_ad.yml.example
@@ -1,5 +1,5 @@
 ---
-# Authentication for Kerberos-based Realms
+# Authentication for Kerberos-based Realms. This will be used to get the DNS of the domain.
 :realm: EXAMPLE.COM
 
 # Kerberos pricipal used to authenticate against Active Directory
@@ -8,7 +8,7 @@
 # Path to the keytab used to authenticate against Active Directory
 :keytab_path:  /etc/foreman-proxy/realm_ad.keytab
 
-# FQDN of the Domain Controller
+# Optional: Only use a specific domain controller. This will disable DNS based dc discovery.
 :domain_controller: dc.example.com
 
 # Optional: OU where the machine account shall be placed

--- a/lib/smart_proxy_realm_ad/provider.rb
+++ b/lib/smart_proxy_realm_ad/provider.rb
@@ -88,6 +88,7 @@ module Proxy::AdRealm
       # Connect to active directory
       conn = Adcli::AdConn.new(@domain)
       conn.set_domain_realm(@realm)
+      # Directly connect to the domain controller if specified, skip the SRV lookup
       conn.set_domain_controller(@domain_controller) unless @domain_controller.nil?
       conn.set_login_ccache_name('')
       conn.connect


### PR DESCRIPTION
By default when connecting to AD dynamic DC discovery will be performed.
We need to clarify that domain_controller is optional, and if set we will only connect to a specific DC.

The realm setting, is used to get the DNS to discover against.
