### PR TITLE
Add frozen string literal comment to all Ruby files

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 gemspec
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rake'
 require 'rake/testtask'
 

--- a/bundler.d/realm_ad_plugin.rb
+++ b/bundler.d/realm_ad_plugin.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 gem 'smart_proxy_realm_ad_plugin'
 gem 'radcli'

--- a/lib/smart_proxy_realm_ad/configuration_loader.rb
+++ b/lib/smart_proxy_realm_ad/configuration_loader.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Proxy::AdRealm
   class ConfigurationLoader
     def load_classes

--- a/lib/smart_proxy_realm_ad/plugin.rb
+++ b/lib/smart_proxy_realm_ad/plugin.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'smart_proxy_realm_ad/version'
 
 module Proxy::AdRealm

--- a/lib/smart_proxy_realm_ad/provider.rb
+++ b/lib/smart_proxy_realm_ad/provider.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'proxy/kerberos'
 require 'radcli'
 require 'digest'

--- a/lib/smart_proxy_realm_ad/version.rb
+++ b/lib/smart_proxy_realm_ad/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Proxy
   module AdRealm
     VERSION = '0.1'.freeze

--- a/lib/smart_proxy_realm_ad_plugin.rb
+++ b/lib/smart_proxy_realm_ad_plugin.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'smart_proxy_realm_ad/configuration_loader'
 require 'smart_proxy_realm_ad/plugin'
 

--- a/smart_proxy_realm_ad_plugin.gemspec
+++ b/smart_proxy_realm_ad_plugin.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require File.expand_path('../lib/smart_proxy_realm_ad/version', __FILE__)
 require 'date'
 

--- a/test/ad_provider_test.rb
+++ b/test/ad_provider_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rubygems'
 require 'test_helper'
 require 'smart_proxy_realm_ad/provider'

--- a/test/internal_api_test.rb
+++ b/test/internal_api_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 require 'rack/test'
 require 'realm/configuration_loader'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test/unit'
 require 'mocha/setup'
 

--- a/test/test_radcli.rb
+++ b/test/test_radcli.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'radcli'
 
 # Connect using password


### PR DESCRIPTION
- Added `# frozen_string_literal: true` to the top of each Ruby file.
- Ensured compliance with RuboCop guidelines.