### PR TITLE
fix/rubocop string literals style

### DIFF
--- a/test/internal_api_test.rb
+++ b/test/internal_api_test.rb
@@ -27,28 +27,28 @@ class InternalApiTest < Test::Unit::TestCase
   end
 
   def setup
-    @server = Proxy::AdRealm::Provider.new(:realm => "test.com")
+    @server = Proxy::AdRealm::Provider.new(:realm => 'test.com')
   end
 
   def test_create_host
-    realm = "TEST.COM"
-    hostname = "test.com"
+    realm = 'TEST.COM'
+    hostname = 'test.com'
     @server.expects(:create).with(realm, hostname, is_a(Hash))
     post "/#{realm}", :hostname => 'test.com'
     assert last_response.ok?, "Last response was not ok: #{last_response.status} #{last_response.body}"
   end
 
   def test_rebuild_host
-    realm = "TEST.COM"
-    hostname = "test.com"
+    realm = 'TEST.COM'
+    hostname = 'test.com'
     @server.expects(:create).with(realm, hostname, has_entry('rebuild', 'true'))
     post "/#{realm}", :hostname => 'test.com', :rebuild => true
     assert last_response.ok?, "Last response was not ok: #{last_response.status} #{last_response.body}"
   end
 
   def test_delete_host
-    realm = "TEST.COM"
-    hostname = "test.com"
+    realm = 'TEST.COM'
+    hostname = 'test.com'
     @server.expects(:delete).with(realm, hostname)
     delete "/#{realm}/#{hostname}"
     assert last_response.ok?, "Last response was not ok: #{last_response.status} #{last_response.body}"

--- a/test/test_radcli.rb
+++ b/test/test_radcli.rb
@@ -3,57 +3,57 @@
 require 'radcli'
 
 # Connect using password
-adconn = Adcli::AdConn.new("example.com")
-adconn.set_domain_realm("EXAMPLE.COM")
-adconn.set_domain_controller("dc.example.com")
-adconn.set_login_user("realm-proxy")
-adconn.set_user_password("password")
+adconn = Adcli::AdConn.new('example.com')
+adconn.set_domain_realm('EXAMPLE.COM')
+adconn.set_domain_controller('dc.example.com')
+adconn.set_login_user('realm-proxy')
+adconn.set_user_password('password')
 res = adconn.connect
 
 # Connect using kerberos keytab
 require 'radcli'
-require "rkerberos"
-principal = "realm-proxy"
-keytab="/etc/foreman-proxy/realm-proxy.keytab"
+require 'rkerberos'
+principal = 'realm-proxy'
+keytab='/etc/foreman-proxy/realm-proxy.keytab'
 krb5 = Kerberos::Krb5.new
 ccache = Kerberos::Krb5::CredentialsCache.new
 krb5.get_init_creds_keytab principal, keytab, nil, ccache
-adconn = Adcli::AdConn.new("example.com")
-adconn.set_domain_realm("EXAMPLE.COM")
-adconn.set_domain_controller("dc.example.com")
-adconn.set_login_ccache_name("")
+adconn = Adcli::AdConn.new('example.com')
+adconn.set_domain_realm('EXAMPLE.COM')
+adconn.set_domain_controller('dc.example.com')
+adconn.set_login_ccache_name('')
 res = adconn.connect
 
 
 # Delete the computer accounts object
 enroll = Adcli::AdEnroll.new(adconn)
-enroll.set_computer_name("server1")
+enroll.set_computer_name('server1')
 enroll.delete()
 
 # Create a computer account object
 enroll = Adcli::AdEnroll.new(adconn)
-enroll.set_computer_name("server1")
-enroll.set_host_fqdn("server1.example.com")
-enroll.set_computer_password("password")
+enroll.set_computer_name('server1')
+enroll.set_host_fqdn('server1.example.com')
+enroll.set_computer_password('password')
 enroll.join()
 
 # Reset a computer accounts password
-adconn.set_domain_controller("dc.example.com")
+adconn.set_domain_controller('dc.example.com')
 enroll = Adcli::AdEnroll.new(adconn)
-enroll.set_computer_name("server1")
-enroll.set_computer_password("newpass")
+enroll.set_computer_name('server1')
+enroll.set_computer_password('newpass')
 enroll.password()
 
 # Delete the computer accounts object
 enroll = Adcli::AdEnroll.new(adconn)
-enroll.set_computer_name("server1")
+enroll.set_computer_name('server1')
 enroll.delete()
 
 
 # Create a computer account object in specific OU
 enroll = Adcli::AdEnroll.new(adconn)
 enroll.set_domain_ou('OU=Computers,OU=Foobar,DC=example,DC=com')
-enroll.set_computer_name("server1")
-enroll.set_host_fqdn("server1.example.com")
-enroll.set_computer_password("password")
+enroll.set_computer_name('server1')
+enroll.set_host_fqdn('server1.example.com')
+enroll.set_computer_password('password')
 enroll.join()


### PR DESCRIPTION
- Changed double-quoted strings to single-quoted strings where interpolation or special symbols are not needed
- Ensured compliance with RuboCop guidelines.